### PR TITLE
Fix issue with request gas prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ You can read the following datasets with this package:
 
 ### Electricity prices
 
+The energy prices are different every hour, after 15:00 (more usually already at 14:00) the prices for the next day are published and it is therefore possible to retrieve these data.
+
 - Current/Next electricity market price (float)
 - Average electricity price (float)
 - Lowest energy price (float)
@@ -55,6 +57,8 @@ You can read the following datasets with this package:
 - Percentage of the current price compared to the maximum price
 
 ### Gas prices
+
+The gas prices do not change per hour, but are fixed for 24 hours. Which means that from 06:00 in the morning the new rate for that day will be used.
 
 - Current/Next gas market price (float)
 - Average gas price (float)

--- a/energyzero/energyzero.py
+++ b/energyzero/energyzero.py
@@ -113,8 +113,10 @@ class EnergyZero:
         Raises:
             EnergyZeroNoDataError: No gas prices found for this period.
         """
-        start_date_utc: datetime = start_date - timedelta(hours=1)
-        end_date_utc: datetime = end_date.replace(hour=22, minute=59, second=59)
+        start_date_utc: datetime = start_date + timedelta(hours=5)
+        end_date_utc: datetime = end_date.replace(
+            hour=5, minute=59, second=59
+        ) + timedelta(days=1)
         data = await self._request(
             "energyprices",
             params={


### PR DESCRIPTION
Bug fix because the current API call returned too much data from the past, causing the min, max function to no longer work properly. From now on, the request call is also better aligned with the refresh time of 06:00 in the morning.