### PR TITLE
fix issue with daylight saving time change

### DIFF
--- a/energyzero/energyzero.py
+++ b/energyzero/energyzero.py
@@ -207,30 +207,31 @@ class EnergyZero:
         ------
             EnergyZeroNoDataError: No energy prices found for this period.
         """
-        # Set the start date to 23:00:00 previous day and the end date to 22:59:59 UTC
-        start_date_utc: datetime = datetime(
+        local_tz = datetime.now(timezone.utc).astimezone().tzinfo
+        # Set start_date to 00:00:00 and the end_date to 23:59:59 and convert to UTC
+        utc_start_date = datetime(
             start_date.year,
             start_date.month,
             start_date.day,
             0,
             0,
             0,
-            tzinfo=timezone.utc,
-        ) - timedelta(hours=1)
-        end_date_utc: datetime = datetime(
+            tzinfo=local_tz,
+        ).astimezone(timezone.utc)
+        utc_end_date = datetime(
             end_date.year,
             end_date.month,
             end_date.day,
-            22,
+            23,
             59,
             59,
-            tzinfo=timezone.utc,
-        )
+            tzinfo=local_tz,
+        ).astimezone(timezone.utc)
         data = await self._request(
             "energyprices",
             params={
-                "fromDate": start_date_utc.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
-                "tillDate": end_date_utc.strftime("%Y-%m-%dT%H:%M:%S.999Z"),
+                "fromDate": utc_start_date.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+                "tillDate": utc_end_date.strftime("%Y-%m-%dT%H:%M:%S.999Z"),
                 "interval": interval,
                 "usageType": 1,
                 "inclBtw": self.incl_btw.lower(),

--- a/energyzero/models.py
+++ b/energyzero/models.py
@@ -23,7 +23,8 @@ def _timed_value(moment: datetime, prices: dict[datetime, float]) -> float | Non
     """
     value = None
     for timestamp, price in prices.items():
-        if timestamp <= moment < (timestamp + timedelta(hours=1)):
+        future_ts = timestamp + timedelta(hours=1)
+        if timestamp <= moment < future_ts:
             value = price
     return value
 

--- a/examples/energy.py
+++ b/examples/energy.py
@@ -12,8 +12,8 @@ async def main() -> None:
     """Show example on fetching the energy prices from EnergyZero."""
     async with EnergyZero() as client:
         local = pytz.timezone("CET")
-        today = date(2023, 2, 8)
-        tomorrow = date(2023, 2, 9)
+        today = date(2023, 3, 28)
+        tomorrow = date(2023, 3, 28)
 
         energy_today = await client.energy_prices(start_date=today, end_date=today)
         energy_tomorrow = await client.energy_prices(

--- a/examples/energy.py
+++ b/examples/energy.py
@@ -12,8 +12,8 @@ async def main() -> None:
     """Show example on fetching the energy prices from EnergyZero."""
     async with EnergyZero() as client:
         local = pytz.timezone("CET")
-        today = date(2023, 3, 28)
-        tomorrow = date(2023, 3, 28)
+        today = date(2023, 3, 29)
+        tomorrow = date(2023, 3, 29)
 
         energy_today = await client.energy_prices(start_date=today, end_date=today)
         energy_tomorrow = await client.energy_prices(

--- a/examples/gas.py
+++ b/examples/gas.py
@@ -9,7 +9,7 @@ from energyzero import EnergyZero
 async def main() -> None:
     """Show example on fetching the gas prices from EnergyZero."""
     async with EnergyZero() as client:
-        today = date(2023, 2, 8)
+        today = date(2023, 3, 28)
 
         gas_today = await client.gas_prices(start_date=today, end_date=today)
         print()

--- a/tests/fixtures/energy.json
+++ b/tests/fixtures/energy.json
@@ -1,6 +1,10 @@
 {
     "Prices": [
         {
+            "price": 0.31,
+            "readingDate": "2022-12-06T22:00:00Z"
+        },
+        {
             "price": 0.35,
             "readingDate": "2022-12-06T23:00:00Z"
         },

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,7 @@ from energyzero import Electricity, EnergyZero, EnergyZeroNoDataError, Gas
 from . import load_fixtures
 
 
-@pytest.mark.freeze_time("2022-12-07 15:00:00 CET")
+@pytest.mark.freeze_time("2022-12-07 15:00:00+01:00")
 async def test_electricity_model(aresponses: ResponsesMockServer) -> None:
     """Test the electricity model at 15:00:00 CET."""
     aresponses.add(
@@ -121,7 +121,7 @@ async def test_no_electricity_data(aresponses: ResponsesMockServer) -> None:
             await client.energy_prices(start_date=today, end_date=today)
 
 
-@pytest.mark.freeze_time("2022-12-07 15:00:00 CET")
+@pytest.mark.freeze_time("2022-12-07 15:00:00+01:00")
 async def test_gas_model(aresponses: ResponsesMockServer) -> None:
     """Test the gas model at 15:00:00 CET."""
     aresponses.add(
@@ -149,7 +149,7 @@ async def test_gas_model(aresponses: ResponsesMockServer) -> None:
         assert gas.price_at_time(next_hour) == 1.47
 
 
-@pytest.mark.freeze_time("2022-12-07 04:00:00 CET")
+@pytest.mark.freeze_time("2022-12-07 04:00:00+01:00")
 async def test_gas_morning_model(aresponses: ResponsesMockServer) -> None:
     """Test the gas model in the morning at 04:00:00 CET."""
     aresponses.add(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,9 +10,9 @@ from energyzero import Electricity, EnergyZero, EnergyZeroNoDataError, Gas
 from . import load_fixtures
 
 
-@pytest.mark.freeze_time("2022-12-07 14:00:00 UTC")
+@pytest.mark.freeze_time("2022-12-07 15:00:00 CET")
 async def test_electricity_model(aresponses: ResponsesMockServer) -> None:
-    """Test the electricity model at 14:00:00 UTC."""
+    """Test the electricity model at 15:00:00 CET."""
     aresponses.add(
         "api.energyzero.nl",
         "/v1/energyprices",
@@ -121,9 +121,9 @@ async def test_no_electricity_data(aresponses: ResponsesMockServer) -> None:
             await client.energy_prices(start_date=today, end_date=today)
 
 
-@pytest.mark.freeze_time("2022-12-07 14:00:00 UTC")
+@pytest.mark.freeze_time("2022-12-07 15:00:00 CET")
 async def test_gas_model(aresponses: ResponsesMockServer) -> None:
-    """Test the gas model at 14:00:00 UTC."""
+    """Test the gas model at 15:00:00 CET."""
     aresponses.add(
         "api.energyzero.nl",
         "/v1/energyprices",
@@ -149,9 +149,9 @@ async def test_gas_model(aresponses: ResponsesMockServer) -> None:
         assert gas.price_at_time(next_hour) == 1.47
 
 
-@pytest.mark.freeze_time("2022-12-07 03:00:00 UTC")
+@pytest.mark.freeze_time("2022-12-07 04:00:00 CET")
 async def test_gas_morning_model(aresponses: ResponsesMockServer) -> None:
-    """Test the gas model in the morning at 03:00:00 UTC."""
+    """Test the gas model in the morning at 04:00:00 CET."""
     aresponses.add(
         "api.energyzero.nl",
         "/v1/energyprices",


### PR DESCRIPTION
Due to the transition to summer time, problems have arisen in the API request due to the way the start and end date are composed in the code, this problem is mainly seen between 00:00 and 01:00 CEST. This is because the UTC offset has moved from 1 hour to 2 hours, so we do not request 1 hour of data from the API at that moment.

With this PR, a local datetime variable is converted to UTC and only then used in the request, instead of setting the variable to the correct times using `replace` and `timedelta`.

Related: https://github.com/home-assistant/core/issues/90331