### PR TITLE
Add support for retrieving multiple price types in one request

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ gas_prices = await client.get_gas_prices(
 ```
 
 Duplicate types appear once, in first-requested order. An empty iterable raises
-`ValueError` without making a request. REST filters each requested stream to the
+`ValueError` without making a request. Values must be `PriceType` members; raw
+strings and other invalid values raise `TypeError` before making a request. REST filters each requested stream to the
 local date and raises `EnergyZeroNoDataError` if a requested stream has no prices
 for that date; no partial mapping is returned. GraphQL requires `end_date` and
 retains its existing date-range behavior. Omitting `price_type` still returns

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Returns electricity prices in **EUR/kWh**.
 | `start_date` | `date`      | Start of the period (local timezone).          |
 | `end_date`   | `date`      | End of the period (local timezone).            |
 | `interval`   | `Interval`  | REST only: `Interval.QUARTER` or `Interval.HOUR`. Ignored by GraphQL. |
-| `price_type` | `PriceType` | Type of price to return. See `PriceType` for options (default `ALL_IN`). |
+| `price_type` | `PriceType` or `Iterable[PriceType]` | One or more price types to return (default `ALL_IN`). |
 | `local_tz`   | `tzinfo`    | Optional explicit timezone used to interpret the requested local date range on REST. |
 
 ---
@@ -164,31 +164,33 @@ Returns gas prices in **EUR/m³**.
 |--------------|-------------|------------------------------------------------|
 | `start_date` | `date`      | Start of the period (local timezone).          |
 | `end_date`   | `date`      | End of the period (local timezone).            |
-| `price_type` | `PriceType` | Type of price to return. See `PriceType` for options (default `ALL_IN`). |
+| `price_type` | `PriceType` or `Iterable[PriceType]` | One or more price types to return (default `ALL_IN`). |
 | `local_tz`   | `tzinfo`    | Optional explicit timezone used to interpret the requested local date range on REST. |
 
 ---
 
-### `get_electricity_prices_by_type()` / `get_gas_prices_by_type()`
+### Retrieving multiple price types
 
 Retrieve multiple price types with **one HTTP request per method call**, on either
-backend. Both methods return `dict[PriceType, EnergyPrices]` and accept the same
-parameters as their single-price counterparts, replacing `price_type` with the
-required keyword argument `price_types` (an iterable of `PriceType` values).
+backend. Pass an iterable of `PriceType` values to the existing `price_type` parameter
+of `get_electricity_prices()` or `get_gas_prices()`. This returns
+`dict[PriceType, EnergyPrices]`, even when the iterable contains only one type.
+Passing a single `PriceType` still returns one `EnergyPrices` object. Type
+overloads infer the return type from the input.
 
 ```python
-prices = await client.get_electricity_prices_by_type(
+prices = await client.get_electricity_prices(
     start_date=today,
     interval=Interval.QUARTER,
-    price_types=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
+    price_type=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
     local_tz=local_tz,
 )
 market_prices = prices[PriceType.MARKET_WITH_VAT]
 all_in_prices = prices[PriceType.ALL_IN]
 
-gas_prices = await client.get_gas_prices_by_type(
+gas_prices = await client.get_gas_prices(
     start_date=today,
-    price_types=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
+    price_type=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
     local_tz=local_tz,
 )
 ```
@@ -197,8 +199,8 @@ Duplicate types appear once, in first-requested order. An empty iterable raises
 `ValueError` without making a request. REST filters each requested stream to the
 local date and raises `EnergyZeroNoDataError` if a requested stream has no prices
 for that date; no partial mapping is returned. GraphQL requires `end_date` and
-retains its existing date-range behavior. The single-price methods still return
-one `EnergyPrices` object and default to `PriceType.ALL_IN`.
+retains its existing date-range behavior. Omitting `price_type` still returns
+one `EnergyPrices` object using `PriceType.ALL_IN`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ Returns gas prices in **EUR/m³**.
 
 ---
 
+### `get_electricity_prices_by_type()` / `get_gas_prices_by_type()`
+
+Retrieve multiple price types with **one HTTP request per method call**, on either
+backend. Both methods return `dict[PriceType, EnergyPrices]` and accept the same
+parameters as their single-price counterparts, replacing `price_type` with the
+required keyword argument `price_types` (an iterable of `PriceType` values).
+
+```python
+prices = await client.get_electricity_prices_by_type(
+    start_date=today,
+    interval=Interval.QUARTER,
+    price_types=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
+    local_tz=local_tz,
+)
+market_prices = prices[PriceType.MARKET_WITH_VAT]
+all_in_prices = prices[PriceType.ALL_IN]
+
+gas_prices = await client.get_gas_prices_by_type(
+    start_date=today,
+    price_types=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
+    local_tz=local_tz,
+)
+```
+
+Duplicate types appear once, in first-requested order. An empty iterable raises
+`ValueError` without making a request. REST filters each requested stream to the
+local date and raises `EnergyZeroNoDataError` if a requested stream has no prices
+for that date; no partial mapping is returned. GraphQL requires `end_date` and
+retains its existing date-range behavior. The single-price methods still return
+one `EnergyPrices` object and default to `PriceType.ALL_IN`.
+
+---
+
 ### `PriceType`
 
 Specifies the type of prices returned by both backends.

--- a/src/energyzero/api/base.py
+++ b/src/energyzero/api/base.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Protocol, overload
 
 from energyzero.const import PriceType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     from datetime import date, tzinfo
 
     from energyzero.models import EnergyPrices
@@ -62,7 +62,8 @@ class EnergyZeroAPIProtocol(Protocol):
 
         Iterable input always returns a mapping, even for one type. Duplicates
         appear once, in first-requested order. Empty iterables raise ValueError
-        before any request. All requested types use one backend request.
+        before any request. Invalid values raise TypeError before any request.
+        All requested types use one backend request.
 
         Args:
         ----
@@ -122,7 +123,8 @@ class EnergyZeroAPIProtocol(Protocol):
 
         Iterable input always returns a mapping, even for one type. Duplicates
         appear once, in first-requested order. Empty iterables raise ValueError
-        before any request. All requested types use one backend request.
+        before any request. Invalid values raise TypeError before any request.
+        All requested types use one backend request.
 
         Args:
         ----
@@ -142,3 +144,26 @@ class EnergyZeroAPIProtocol(Protocol):
     async def close(self) -> None:
         """Close the API client and cleanup resources."""
         raise NotImplementedError
+
+
+def _normalize_price_types(
+    price_type: PriceType | Iterable[PriceType],
+) -> tuple[PriceType, ...]:
+    """Validate requested price types and deduplicate in first-requested order."""
+    if isinstance(price_type, PriceType):
+        return (price_type,)
+
+    if isinstance(price_type, (str, bytes)) or not isinstance(price_type, Iterable):
+        msg = "price_type must be a PriceType or an iterable of PriceType values."
+        raise TypeError(msg)
+
+    requested_types = tuple(price_type)
+    if not requested_types:
+        msg = "At least one price type is required."
+        raise ValueError(msg)
+
+    if any(not isinstance(item, PriceType) for item in requested_types):
+        msg = "Every item in price_type must be a PriceType value."
+        raise TypeError(msg)
+
+    return tuple(dict.fromkeys(requested_types))

--- a/src/energyzero/api/base.py
+++ b/src/energyzero/api/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, overload
 
 from energyzero.const import PriceType
 
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 class EnergyZeroAPIProtocol(Protocol):
     """Protocol defining the interface for EnergyZero API clients."""
 
+    @overload
     async def get_electricity_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -24,8 +25,44 @@ class EnergyZeroAPIProtocol(Protocol):
         price_type: PriceType = PriceType.ALL_IN,
         *,
         local_tz: tzinfo | None = None,
-    ) -> EnergyPrices:
+    ) -> EnergyPrices: ...
+
+    @overload
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None,
+        interval: str,
+        price_type: Iterable[PriceType],
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    @overload
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: str = "INTERVAL_QUARTER",
+        *,
+        price_type: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: str = "INTERVAL_QUARTER",
+        price_type: PriceType | Iterable[PriceType] = PriceType.ALL_IN,
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> EnergyPrices | dict[PriceType, EnergyPrices]:
         """Get electricity prices for a given period.
+
+        Iterable input always returns a mapping, even for one type. Duplicates
+        appear once, in first-requested order. Empty iterables raise ValueError
+        before any request. All requested types use one backend request.
 
         Args:
         ----
@@ -33,35 +70,17 @@ class EnergyZeroAPIProtocol(Protocol):
             end_date: Optional end date (GraphQL requires this parameter; REST
                 requires an identical date and only supports single-day requests).
             interval: Interval type (INTERVAL_QUARTER, INTERVAL_HOUR).
-            price_type: Type of price (ALL_IN or MARKET).
+            price_type: One PriceType or an iterable of types (default: ALL_IN).
             local_tz: Timezone used to interpret the requested local date range.
 
         Returns:
         -------
-            An EnergyPrices object.
+            One EnergyPrices for a single PriceType; a mapping for an iterable.
 
         """
         raise NotImplementedError
 
-    async def get_electricity_prices_by_type(  # pylint: disable=too-many-arguments
-        self,
-        start_date: date,
-        end_date: date | None = None,
-        interval: str = "INTERVAL_QUARTER",
-        *,
-        price_types: Iterable[PriceType],
-        local_tz: tzinfo | None = None,
-    ) -> dict[PriceType, EnergyPrices]:
-        """Get multiple electricity price types with one backend request.
-
-        Uses the same date, timezone and interval semantics as
-        ``get_electricity_prices``. Values are in EUR/kWh.
-        ``price_types`` accepts an iterable; duplicates are returned once,
-        in first-requested order. An empty iterable raises ``ValueError``
-        before making a request. Returns a mapping of types to EnergyPrices.
-        """
-        raise NotImplementedError
-
+    @overload
     async def get_gas_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -69,39 +88,54 @@ class EnergyZeroAPIProtocol(Protocol):
         price_type: PriceType = PriceType.ALL_IN,
         *,
         local_tz: tzinfo | None = None,
-    ) -> EnergyPrices:
+    ) -> EnergyPrices: ...
+
+    @overload
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None,
+        price_type: Iterable[PriceType],
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    @overload
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        *,
+        price_type: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        price_type: PriceType | Iterable[PriceType] = PriceType.ALL_IN,
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> EnergyPrices | dict[PriceType, EnergyPrices]:
         """Get gas prices for a given period.
+
+        Iterable input always returns a mapping, even for one type. Duplicates
+        appear once, in first-requested order. Empty iterables raise ValueError
+        before any request. All requested types use one backend request.
 
         Args:
         ----
             start_date: Start date of the period (local timezone).
             end_date: Optional end date (GraphQL requires this parameter; REST
                 requires an identical date and only supports single-day requests).
-            price_type: Type of price (ALL_IN or MARKET).
+            price_type: One PriceType or an iterable of types (default: ALL_IN).
             local_tz: Timezone used to interpret the requested local date range.
 
         Returns:
         -------
-            An EnergyPrices object.
+            One EnergyPrices for a single PriceType; a mapping for an iterable.
 
-        """
-        raise NotImplementedError
-
-    async def get_gas_prices_by_type(  # pylint: disable=too-many-arguments
-        self,
-        start_date: date,
-        end_date: date | None = None,
-        *,
-        price_types: Iterable[PriceType],
-        local_tz: tzinfo | None = None,
-    ) -> dict[PriceType, EnergyPrices]:
-        """Get multiple gas price types with one backend request.
-
-        Uses the same date, timezone and interval semantics as
-        ``get_gas_prices``. Values are in EUR/m³.
-        ``price_types`` accepts an iterable; duplicates are returned once,
-        in first-requested order. An empty iterable raises ``ValueError``
-        before making a request. Returns a mapping of types to EnergyPrices.
         """
         raise NotImplementedError
 

--- a/src/energyzero/api/base.py
+++ b/src/energyzero/api/base.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 from energyzero.const import PriceType
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from datetime import date, tzinfo
 
     from energyzero.models import EnergyPrices
@@ -30,7 +31,7 @@ class EnergyZeroAPIProtocol(Protocol):
         ----
             start_date: Start date of the period (local timezone).
             end_date: Optional end date (GraphQL requires this parameter; REST
-                ignores it and only supports single-day requests).
+                requires an identical date and only supports single-day requests).
             interval: Interval type (INTERVAL_QUARTER, INTERVAL_HOUR).
             price_type: Type of price (ALL_IN or MARKET).
             local_tz: Timezone used to interpret the requested local date range.
@@ -39,6 +40,25 @@ class EnergyZeroAPIProtocol(Protocol):
         -------
             An EnergyPrices object.
 
+        """
+        raise NotImplementedError
+
+    async def get_electricity_prices_by_type(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: str = "INTERVAL_QUARTER",
+        *,
+        price_types: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]:
+        """Get multiple electricity price types with one backend request.
+
+        Uses the same date, timezone and interval semantics as
+        ``get_electricity_prices``. Values are in EUR/kWh.
+        ``price_types`` accepts an iterable; duplicates are returned once,
+        in first-requested order. An empty iterable raises ``ValueError``
+        before making a request. Returns a mapping of types to EnergyPrices.
         """
         raise NotImplementedError
 
@@ -56,7 +76,7 @@ class EnergyZeroAPIProtocol(Protocol):
         ----
             start_date: Start date of the period (local timezone).
             end_date: Optional end date (GraphQL requires this parameter; REST
-                ignores it and only supports single-day requests).
+                requires an identical date and only supports single-day requests).
             price_type: Type of price (ALL_IN or MARKET).
             local_tz: Timezone used to interpret the requested local date range.
 
@@ -64,6 +84,24 @@ class EnergyZeroAPIProtocol(Protocol):
         -------
             An EnergyPrices object.
 
+        """
+        raise NotImplementedError
+
+    async def get_gas_prices_by_type(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        *,
+        price_types: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]:
+        """Get multiple gas price types with one backend request.
+
+        Uses the same date, timezone and interval semantics as
+        ``get_gas_prices``. Values are in EUR/m³.
+        ``price_types`` accepts an iterable; duplicates are returned once,
+        in first-requested order. An empty iterable raises ``ValueError``
+        before making a request. Returns a mapping of types to EnergyPrices.
         """
         raise NotImplementedError
 

--- a/src/energyzero/api/graphql.py
+++ b/src/energyzero/api/graphql.py
@@ -13,6 +13,7 @@ from aiohttp.client import ClientError, ClientSession
 from aiohttp.hdrs import METH_POST
 from yarl import URL
 
+from energyzero.api.base import _normalize_price_types
 from energyzero.const import PriceType
 from energyzero.exceptions import (
     EnergyZeroConnectionError,
@@ -181,7 +182,8 @@ class GraphQLClient:
 
         Iterable input always returns a mapping, even for one type. Duplicates
         appear once, in first-requested order. Empty iterables raise ValueError
-        before any request. All requested types use one backend request.
+        before any request. Invalid values raise TypeError before any request.
+        All requested types use one backend request.
 
         Args:
         ----
@@ -200,14 +202,7 @@ class GraphQLClient:
             EnergyZeroNoDataError: No data found.
 
         """
-        requested_types = (
-            (price_type,)
-            if isinstance(price_type, PriceType)
-            else tuple(dict.fromkeys(price_type))
-        )
-        if not requested_types:
-            msg = "At least one price type is required."
-            raise ValueError(msg)
+        requested_types = _normalize_price_types(price_type)
 
         _ = interval  # GraphQL backend always returns hourly intervals.
         if end_date is None:
@@ -309,7 +304,8 @@ class GraphQLClient:
 
         Iterable input always returns a mapping, even for one type. Duplicates
         appear once, in first-requested order. Empty iterables raise ValueError
-        before any request. All requested types use one backend request.
+        before any request. Invalid values raise TypeError before any request.
+        All requested types use one backend request.
 
         Args:
         ----
@@ -327,14 +323,7 @@ class GraphQLClient:
             EnergyZeroNoDataError: No data found.
 
         """
-        requested_types = (
-            (price_type,)
-            if isinstance(price_type, PriceType)
-            else tuple(dict.fromkeys(price_type))
-        )
-        if not requested_types:
-            msg = "At least one price type is required."
-            raise ValueError(msg)
+        requested_types = _normalize_price_types(price_type)
 
         if end_date is None:
             msg = "end_date is required when using the GraphQL backend."

--- a/src/energyzero/api/graphql.py
+++ b/src/energyzero/api/graphql.py
@@ -7,7 +7,7 @@ import socket
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta, tzinfo
 from importlib import metadata
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aiohttp.client import ClientError, ClientSession
 from aiohttp.hdrs import METH_POST
@@ -20,6 +20,9 @@ from energyzero.exceptions import (
     EnergyZeroNoDataError,
 )
 from energyzero.models import EnergyPrices
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 VERSION = metadata.version("energyzero")
 
@@ -160,6 +163,37 @@ class GraphQLClient:
             EnergyZeroNoDataError: No data found.
 
         """
+        prices = await self.get_electricity_prices_by_type(
+            start_date,
+            end_date,
+            interval,
+            price_types=(price_type,),
+            local_tz=local_tz,
+        )
+        return prices[price_type]
+
+    async def get_electricity_prices_by_type(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: str = "INTERVAL_QUARTER",
+        *,
+        price_types: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]:
+        """Get multiple electricity price types with one backend request.
+
+        Uses the same date, timezone and interval semantics as
+        ``get_electricity_prices``. Values are in EUR/kWh.
+        ``price_types`` accepts an iterable; duplicates are returned once,
+        in first-requested order. An empty iterable raises ``ValueError``
+        before making a request. Returns a mapping of types to EnergyPrices.
+        """
+        requested_types = tuple(dict.fromkeys(price_types))
+        if not requested_types:
+            msg = "At least one price type is required."
+            raise ValueError(msg)
+
         _ = interval  # GraphQL backend always returns hourly intervals.
         if end_date is None:
             msg = "end_date is required when using the GraphQL backend."
@@ -212,7 +246,10 @@ class GraphQLClient:
             msg = "No energy prices found for this period."
             raise EnergyZeroNoDataError(message=msg)
 
-        return EnergyPrices.from_dict(data["data"], price_type)
+        return {
+            price_type: EnergyPrices.from_dict(data["data"], price_type)
+            for price_type in requested_types
+        }
 
     async def get_gas_prices(  # pylint: disable=too-many-arguments
         self,
@@ -240,6 +277,35 @@ class GraphQLClient:
             EnergyZeroNoDataError: No data found.
 
         """
+        prices = await self.get_gas_prices_by_type(
+            start_date,
+            end_date,
+            price_types=(price_type,),
+            local_tz=local_tz,
+        )
+        return prices[price_type]
+
+    async def get_gas_prices_by_type(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        *,
+        price_types: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]:
+        """Get multiple gas price types with one backend request.
+
+        Uses the same date, timezone and interval semantics as
+        ``get_gas_prices``. Values are in EUR/m³.
+        ``price_types`` accepts an iterable; duplicates are returned once,
+        in first-requested order. An empty iterable raises ``ValueError``
+        before making a request. Returns a mapping of types to EnergyPrices.
+        """
+        requested_types = tuple(dict.fromkeys(price_types))
+        if not requested_types:
+            msg = "At least one price type is required."
+            raise ValueError(msg)
+
         if end_date is None:
             msg = "end_date is required when using the GraphQL backend."
             raise ValueError(msg)
@@ -292,7 +358,10 @@ class GraphQLClient:
             msg = "No gas prices found for this period."
             raise EnergyZeroNoDataError(message=msg)
 
-        return EnergyPrices.from_dict(data["data"], price_type)
+        return {
+            price_type: EnergyPrices.from_dict(data["data"], price_type)
+            for price_type in requested_types
+        }
 
     async def close(self) -> None:
         """Close the client session."""

--- a/src/energyzero/api/graphql.py
+++ b/src/energyzero/api/graphql.py
@@ -7,7 +7,7 @@ import socket
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta, tzinfo
 from importlib import metadata
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 from aiohttp.client import ClientError, ClientSession
 from aiohttp.hdrs import METH_POST
@@ -135,6 +135,7 @@ class GraphQLClient:
 
         return data
 
+    @overload
     async def get_electricity_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -143,53 +144,67 @@ class GraphQLClient:
         price_type: PriceType = PriceType.ALL_IN,
         *,
         local_tz: tzinfo | None = None,
-    ) -> EnergyPrices:
+    ) -> EnergyPrices: ...
+
+    @overload
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None,
+        interval: str,
+        price_type: Iterable[PriceType],
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    @overload
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: str = "INTERVAL_QUARTER",
+        *,
+        price_type: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: str = "INTERVAL_QUARTER",
+        price_type: PriceType | Iterable[PriceType] = PriceType.ALL_IN,
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> EnergyPrices | dict[PriceType, EnergyPrices]:
         """Get electricity prices using GraphQL API.
+
+        Iterable input always returns a mapping, even for one type. Duplicates
+        appear once, in first-requested order. Empty iterables raise ValueError
+        before any request. All requested types use one backend request.
 
         Args:
         ----
             start_date: Start date (local timezone).
             end_date: Optional end date (GraphQL requires this value).
             interval: Interval type (ignored, GraphQL only supports hourly).
-            price_type: Desired price flavor. See ``PriceType`` for options.
+            price_type: One PriceType or an iterable of types (default: ALL_IN).
             local_tz: Unused for GraphQL. Present for API compatibility.
 
         Returns:
         -------
-            An EnergyPrices object.
+            One EnergyPrices for a single PriceType; a mapping for an iterable.
 
         Raises:
         ------
             EnergyZeroNoDataError: No data found.
 
         """
-        prices = await self.get_electricity_prices_by_type(
-            start_date,
-            end_date,
-            interval,
-            price_types=(price_type,),
-            local_tz=local_tz,
+        requested_types = (
+            (price_type,)
+            if isinstance(price_type, PriceType)
+            else tuple(dict.fromkeys(price_type))
         )
-        return prices[price_type]
-
-    async def get_electricity_prices_by_type(  # pylint: disable=too-many-arguments
-        self,
-        start_date: date,
-        end_date: date | None = None,
-        interval: str = "INTERVAL_QUARTER",
-        *,
-        price_types: Iterable[PriceType],
-        local_tz: tzinfo | None = None,
-    ) -> dict[PriceType, EnergyPrices]:
-        """Get multiple electricity price types with one backend request.
-
-        Uses the same date, timezone and interval semantics as
-        ``get_electricity_prices``. Values are in EUR/kWh.
-        ``price_types`` accepts an iterable; duplicates are returned once,
-        in first-requested order. An empty iterable raises ``ValueError``
-        before making a request. Returns a mapping of types to EnergyPrices.
-        """
-        requested_types = tuple(dict.fromkeys(price_types))
         if not requested_types:
             msg = "At least one price type is required."
             raise ValueError(msg)
@@ -246,11 +261,13 @@ class GraphQLClient:
             msg = "No energy prices found for this period."
             raise EnergyZeroNoDataError(message=msg)
 
-        return {
-            price_type: EnergyPrices.from_dict(data["data"], price_type)
-            for price_type in requested_types
+        results = {
+            requested_type: EnergyPrices.from_dict(data["data"], requested_type)
+            for requested_type in requested_types
         }
+        return results[price_type] if isinstance(price_type, PriceType) else results
 
+    @overload
     async def get_gas_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -258,50 +275,63 @@ class GraphQLClient:
         price_type: PriceType = PriceType.ALL_IN,
         *,
         local_tz: tzinfo | None = None,
-    ) -> EnergyPrices:
+    ) -> EnergyPrices: ...
+
+    @overload
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None,
+        price_type: Iterable[PriceType],
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    @overload
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        *,
+        price_type: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        price_type: PriceType | Iterable[PriceType] = PriceType.ALL_IN,
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> EnergyPrices | dict[PriceType, EnergyPrices]:
         """Get gas prices using GraphQL API.
+
+        Iterable input always returns a mapping, even for one type. Duplicates
+        appear once, in first-requested order. Empty iterables raise ValueError
+        before any request. All requested types use one backend request.
 
         Args:
         ----
             start_date: Start date (local timezone).
             end_date: Optional end date (GraphQL requires this value).
-            price_type: ALL_IN or MARKET prices.
+            price_type: One PriceType or an iterable of types (default: ALL_IN).
             local_tz: Unused for GraphQL. Present for API compatibility.
 
         Returns:
         -------
-            An EnergyPrices object.
+            One EnergyPrices for a single PriceType; a mapping for an iterable.
 
         Raises:
         ------
             EnergyZeroNoDataError: No data found.
 
         """
-        prices = await self.get_gas_prices_by_type(
-            start_date,
-            end_date,
-            price_types=(price_type,),
-            local_tz=local_tz,
+        requested_types = (
+            (price_type,)
+            if isinstance(price_type, PriceType)
+            else tuple(dict.fromkeys(price_type))
         )
-        return prices[price_type]
-
-    async def get_gas_prices_by_type(  # pylint: disable=too-many-arguments
-        self,
-        start_date: date,
-        end_date: date | None = None,
-        *,
-        price_types: Iterable[PriceType],
-        local_tz: tzinfo | None = None,
-    ) -> dict[PriceType, EnergyPrices]:
-        """Get multiple gas price types with one backend request.
-
-        Uses the same date, timezone and interval semantics as
-        ``get_gas_prices``. Values are in EUR/m³.
-        ``price_types`` accepts an iterable; duplicates are returned once,
-        in first-requested order. An empty iterable raises ``ValueError``
-        before making a request. Returns a mapping of types to EnergyPrices.
-        """
-        requested_types = tuple(dict.fromkeys(price_types))
         if not requested_types:
             msg = "At least one price type is required."
             raise ValueError(msg)
@@ -358,10 +388,11 @@ class GraphQLClient:
             msg = "No gas prices found for this period."
             raise EnergyZeroNoDataError(message=msg)
 
-        return {
-            price_type: EnergyPrices.from_dict(data["data"], price_type)
-            for price_type in requested_types
+        results = {
+            requested_type: EnergyPrices.from_dict(data["data"], requested_type)
+            for requested_type in requested_types
         }
+        return results[price_type] if isinstance(price_type, PriceType) else results
 
     async def close(self) -> None:
         """Close the client session."""

--- a/src/energyzero/api/rest.py
+++ b/src/energyzero/api/rest.py
@@ -8,7 +8,7 @@ import socket
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, tzinfo
 from importlib import metadata
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aiohttp.client import ClientError, ClientSession
 from aiohttp.hdrs import METH_GET
@@ -21,6 +21,9 @@ from energyzero.exceptions import (
     EnergyZeroNoDataError,
 )
 from energyzero.models import REST_PRICE_STREAMS, EnergyPrices, _parse_datetime_str
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 VERSION = metadata.version("energyzero")
 
@@ -140,7 +143,7 @@ class RESTClient:
         stream = REST_PRICE_STREAMS[price_type]
         filtered_stream = [
             item
-            for item in data[stream]
+            for item in data.get(stream, [])
             if _parse_datetime_str(item["start"]).astimezone(local_tz).date()
             == filter_date
         ]
@@ -177,6 +180,37 @@ class RESTClient:
             EnergyZeroNoDataError: No data found.
 
         """
+        prices = await self.get_electricity_prices_by_type(
+            start_date,
+            end_date,
+            interval,
+            price_types=(price_type,),
+            local_tz=local_tz,
+        )
+        return prices[price_type]
+
+    async def get_electricity_prices_by_type(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: Interval | str = Interval.QUARTER,
+        *,
+        price_types: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]:
+        """Get multiple electricity price types with one backend request.
+
+        Uses the same date, timezone and interval semantics as
+        ``get_electricity_prices``. Values are in EUR/kWh.
+        ``price_types`` accepts an iterable; duplicates are returned once,
+        in first-requested order. An empty iterable raises ``ValueError``
+        before making a request. Returns a mapping of types to EnergyPrices.
+        """
+        requested_types = tuple(dict.fromkeys(price_types))
+        if not requested_types:
+            msg = "At least one price type is required."
+            raise ValueError(msg)
+
         if end_date and end_date != start_date:
             msg = "REST API supports single-day requests. Use identical dates."
             raise ValueError(msg)
@@ -199,20 +233,24 @@ class RESTClient:
             raise EnergyZeroNoDataError(message=msg)
 
         local_tz = local_tz or self._get_local_timezone()
-        filtered_data = self._filter_data_for_local_date(
-            data,
-            price_type,
-            start_date,
-            local_tz,
-        )
+        results: dict[PriceType, EnergyPrices] = {}
+        for price_type in requested_types:
+            filtered_data = self._filter_data_for_local_date(
+                data,
+                price_type,
+                start_date,
+                local_tz,
+            )
 
-        prices = EnergyPrices.from_rest_dict(filtered_data, price_type)
+            prices = EnergyPrices.from_rest_dict(filtered_data, price_type)
 
-        if len(prices.prices) == 0:
-            msg = f"No electricity prices found for {start_date}"
-            raise EnergyZeroNoDataError(message=msg)
+            if len(prices.prices) == 0:
+                msg = f"No electricity prices found for {start_date}"
+                raise EnergyZeroNoDataError(message=msg)
 
-        return prices
+            results[price_type] = prices
+
+        return results
 
     async def get_gas_prices(  # pylint: disable=too-many-arguments
         self,
@@ -243,6 +281,35 @@ class RESTClient:
             EnergyZeroNoDataError: No data found.
 
         """
+        prices = await self.get_gas_prices_by_type(
+            start_date,
+            end_date,
+            price_types=(price_type,),
+            local_tz=local_tz,
+        )
+        return prices[price_type]
+
+    async def get_gas_prices_by_type(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        *,
+        price_types: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]:
+        """Get multiple gas price types with one backend request.
+
+        Uses the same date, timezone and interval semantics as
+        ``get_gas_prices``. Values are in EUR/m³.
+        ``price_types`` accepts an iterable; duplicates are returned once,
+        in first-requested order. An empty iterable raises ``ValueError``
+        before making a request. Returns a mapping of types to EnergyPrices.
+        """
+        requested_types = tuple(dict.fromkeys(price_types))
+        if not requested_types:
+            msg = "At least one price type is required."
+            raise ValueError(msg)
+
         if end_date and end_date != start_date:
             msg = "REST API supports single-day requests. Use identical dates."
             raise ValueError(msg)
@@ -263,20 +330,24 @@ class RESTClient:
             raise EnergyZeroNoDataError(message=msg)
 
         local_tz = local_tz or self._get_local_timezone()
-        filtered_data = self._filter_data_for_local_date(
-            data,
-            price_type,
-            start_date,
-            local_tz,
-        )
+        results: dict[PriceType, EnergyPrices] = {}
+        for price_type in requested_types:
+            filtered_data = self._filter_data_for_local_date(
+                data,
+                price_type,
+                start_date,
+                local_tz,
+            )
 
-        prices = EnergyPrices.from_rest_dict(filtered_data, price_type)
+            prices = EnergyPrices.from_rest_dict(filtered_data, price_type)
 
-        if len(prices.prices) == 0:
-            msg = f"No gas prices found for {start_date}"
-            raise EnergyZeroNoDataError(message=msg)
+            if len(prices.prices) == 0:
+                msg = f"No gas prices found for {start_date}"
+                raise EnergyZeroNoDataError(message=msg)
 
-        return prices
+            results[price_type] = prices
+
+        return results
 
     async def close(self) -> None:
         """Close the client session."""

--- a/src/energyzero/api/rest.py
+++ b/src/energyzero/api/rest.py
@@ -8,7 +8,7 @@ import socket
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, tzinfo
 from importlib import metadata
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 from aiohttp.client import ClientError, ClientSession
 from aiohttp.hdrs import METH_GET
@@ -149,6 +149,7 @@ class RESTClient:
         ]
         return {**data, stream: filtered_stream}
 
+    @overload
     async def get_electricity_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -157,10 +158,46 @@ class RESTClient:
         price_type: PriceType = PriceType.ALL_IN,
         *,
         local_tz: tzinfo | None = None,
-    ) -> EnergyPrices:
+    ) -> EnergyPrices: ...
+
+    @overload
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None,
+        interval: Interval | str,
+        price_type: Iterable[PriceType],
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    @overload
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: Interval | str = Interval.QUARTER,
+        *,
+        price_type: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: Interval | str = Interval.QUARTER,
+        price_type: PriceType | Iterable[PriceType] = PriceType.ALL_IN,
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> EnergyPrices | dict[PriceType, EnergyPrices]:
         """Get electricity prices using REST API.
 
         All returned price values are in EUR/kWh.
+
+        Iterable input always returns a mapping, even for one type. Duplicates
+        appear once, in first-requested order. Empty iterables raise ValueError
+        before any request. All requested types use one backend request.
 
         Args:
         ----
@@ -168,45 +205,23 @@ class RESTClient:
             end_date: Optional end date. REST API supports single-day requests
                 only; when provided it must match ``start_date``.
             interval: INTERVAL_QUARTER (15 min) or INTERVAL_HOUR.
-            price_type: ALL_IN or MARKET prices.
+            price_type: One PriceType or an iterable of types (default: ALL_IN).
             local_tz: Timezone used to interpret the requested local date range.
 
         Returns:
         -------
-            An EnergyPrices object.
+            One EnergyPrices for a single PriceType; a mapping for an iterable.
 
         Raises:
         ------
             EnergyZeroNoDataError: No data found.
 
         """
-        prices = await self.get_electricity_prices_by_type(
-            start_date,
-            end_date,
-            interval,
-            price_types=(price_type,),
-            local_tz=local_tz,
+        requested_types = (
+            (price_type,)
+            if isinstance(price_type, PriceType)
+            else tuple(dict.fromkeys(price_type))
         )
-        return prices[price_type]
-
-    async def get_electricity_prices_by_type(  # pylint: disable=too-many-arguments
-        self,
-        start_date: date,
-        end_date: date | None = None,
-        interval: Interval | str = Interval.QUARTER,
-        *,
-        price_types: Iterable[PriceType],
-        local_tz: tzinfo | None = None,
-    ) -> dict[PriceType, EnergyPrices]:
-        """Get multiple electricity price types with one backend request.
-
-        Uses the same date, timezone and interval semantics as
-        ``get_electricity_prices``. Values are in EUR/kWh.
-        ``price_types`` accepts an iterable; duplicates are returned once,
-        in first-requested order. An empty iterable raises ``ValueError``
-        before making a request. Returns a mapping of types to EnergyPrices.
-        """
-        requested_types = tuple(dict.fromkeys(price_types))
         if not requested_types:
             msg = "At least one price type is required."
             raise ValueError(msg)
@@ -234,24 +249,25 @@ class RESTClient:
 
         local_tz = local_tz or self._get_local_timezone()
         results: dict[PriceType, EnergyPrices] = {}
-        for price_type in requested_types:
+        for requested_type in requested_types:
             filtered_data = self._filter_data_for_local_date(
                 data,
-                price_type,
+                requested_type,
                 start_date,
                 local_tz,
             )
 
-            prices = EnergyPrices.from_rest_dict(filtered_data, price_type)
+            prices = EnergyPrices.from_rest_dict(filtered_data, requested_type)
 
             if len(prices.prices) == 0:
                 msg = f"No electricity prices found for {start_date}"
                 raise EnergyZeroNoDataError(message=msg)
 
-            results[price_type] = prices
+            results[requested_type] = prices
 
-        return results
+        return results[price_type] if isinstance(price_type, PriceType) else results
 
+    @overload
     async def get_gas_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -259,53 +275,66 @@ class RESTClient:
         price_type: PriceType = PriceType.ALL_IN,
         *,
         local_tz: tzinfo | None = None,
-    ) -> EnergyPrices:
+    ) -> EnergyPrices: ...
+
+    @overload
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None,
+        price_type: Iterable[PriceType],
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    @overload
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        *,
+        price_type: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        price_type: PriceType | Iterable[PriceType] = PriceType.ALL_IN,
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> EnergyPrices | dict[PriceType, EnergyPrices]:
         """Get gas prices using REST API.
 
         All returned price values are in EUR/m³.
+
+        Iterable input always returns a mapping, even for one type. Duplicates
+        appear once, in first-requested order. Empty iterables raise ValueError
+        before any request. All requested types use one backend request.
 
         Args:
         ----
             start_date: Start date (local timezone).
             end_date: Optional end date. REST API supports single-day requests
                 only; when provided it must match ``start_date``.
-            price_type: ALL_IN or MARKET prices.
+            price_type: One PriceType or an iterable of types (default: ALL_IN).
             local_tz: Timezone used to interpret the requested local date range.
 
         Returns:
         -------
-            An EnergyPrices object.
+            One EnergyPrices for a single PriceType; a mapping for an iterable.
 
         Raises:
         ------
             EnergyZeroNoDataError: No data found.
 
         """
-        prices = await self.get_gas_prices_by_type(
-            start_date,
-            end_date,
-            price_types=(price_type,),
-            local_tz=local_tz,
+        requested_types = (
+            (price_type,)
+            if isinstance(price_type, PriceType)
+            else tuple(dict.fromkeys(price_type))
         )
-        return prices[price_type]
-
-    async def get_gas_prices_by_type(  # pylint: disable=too-many-arguments
-        self,
-        start_date: date,
-        end_date: date | None = None,
-        *,
-        price_types: Iterable[PriceType],
-        local_tz: tzinfo | None = None,
-    ) -> dict[PriceType, EnergyPrices]:
-        """Get multiple gas price types with one backend request.
-
-        Uses the same date, timezone and interval semantics as
-        ``get_gas_prices``. Values are in EUR/m³.
-        ``price_types`` accepts an iterable; duplicates are returned once,
-        in first-requested order. An empty iterable raises ``ValueError``
-        before making a request. Returns a mapping of types to EnergyPrices.
-        """
-        requested_types = tuple(dict.fromkeys(price_types))
         if not requested_types:
             msg = "At least one price type is required."
             raise ValueError(msg)
@@ -331,23 +360,23 @@ class RESTClient:
 
         local_tz = local_tz or self._get_local_timezone()
         results: dict[PriceType, EnergyPrices] = {}
-        for price_type in requested_types:
+        for requested_type in requested_types:
             filtered_data = self._filter_data_for_local_date(
                 data,
-                price_type,
+                requested_type,
                 start_date,
                 local_tz,
             )
 
-            prices = EnergyPrices.from_rest_dict(filtered_data, price_type)
+            prices = EnergyPrices.from_rest_dict(filtered_data, requested_type)
 
             if len(prices.prices) == 0:
                 msg = f"No gas prices found for {start_date}"
                 raise EnergyZeroNoDataError(message=msg)
 
-            results[price_type] = prices
+            results[requested_type] = prices
 
-        return results
+        return results[price_type] if isinstance(price_type, PriceType) else results
 
     async def close(self) -> None:
         """Close the client session."""

--- a/src/energyzero/api/rest.py
+++ b/src/energyzero/api/rest.py
@@ -14,6 +14,7 @@ from aiohttp.client import ClientError, ClientSession
 from aiohttp.hdrs import METH_GET
 from yarl import URL
 
+from energyzero.api.base import _normalize_price_types
 from energyzero.const import Interval, PriceType
 from energyzero.exceptions import (
     EnergyZeroConnectionError,
@@ -197,7 +198,8 @@ class RESTClient:
 
         Iterable input always returns a mapping, even for one type. Duplicates
         appear once, in first-requested order. Empty iterables raise ValueError
-        before any request. All requested types use one backend request.
+        before any request. Invalid values raise TypeError before any request.
+        All requested types use one backend request.
 
         Args:
         ----
@@ -217,14 +219,7 @@ class RESTClient:
             EnergyZeroNoDataError: No data found.
 
         """
-        requested_types = (
-            (price_type,)
-            if isinstance(price_type, PriceType)
-            else tuple(dict.fromkeys(price_type))
-        )
-        if not requested_types:
-            msg = "At least one price type is required."
-            raise ValueError(msg)
+        requested_types = _normalize_price_types(price_type)
 
         if end_date and end_date != start_date:
             msg = "REST API supports single-day requests. Use identical dates."
@@ -311,7 +306,8 @@ class RESTClient:
 
         Iterable input always returns a mapping, even for one type. Duplicates
         appear once, in first-requested order. Empty iterables raise ValueError
-        before any request. All requested types use one backend request.
+        before any request. Invalid values raise TypeError before any request.
+        All requested types use one backend request.
 
         Args:
         ----
@@ -330,14 +326,7 @@ class RESTClient:
             EnergyZeroNoDataError: No data found.
 
         """
-        requested_types = (
-            (price_type,)
-            if isinstance(price_type, PriceType)
-            else tuple(dict.fromkeys(price_type))
-        )
-        if not requested_types:
-            msg = "At least one price type is required."
-            raise ValueError(msg)
+        requested_types = _normalize_price_types(price_type)
 
         if end_date and end_date != start_date:
             msg = "REST API supports single-day requests. Use identical dates."

--- a/src/energyzero/energyzero.py
+++ b/src/energyzero/energyzero.py
@@ -97,7 +97,8 @@ class EnergyZero:
 
         Iterable input always returns a mapping, even for one type. Duplicates
         appear once, in first-requested order. Empty iterables raise ValueError
-        before any request. All requested types use one backend request.
+        before any request. Invalid values raise TypeError before any request.
+        All requested types use one backend request.
 
         Args:
         ----
@@ -168,7 +169,8 @@ class EnergyZero:
 
         Iterable input always returns a mapping, even for one type. Duplicates
         appear once, in first-requested order. Empty iterables raise ValueError
-        before any request. All requested types use one backend request.
+        before any request. Invalid values raise TypeError before any request.
+        All requested types use one backend request.
 
         Args:
         ----

--- a/src/energyzero/energyzero.py
+++ b/src/energyzero/energyzero.py
@@ -11,6 +11,7 @@ from energyzero.api.rest import RESTClient
 from energyzero.const import Interval, PriceType
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from datetime import date, tzinfo
 
     from aiohttp.client import ClientSession
@@ -65,7 +66,7 @@ class EnergyZero:
         ----
             start_date: Start date of the period (local timezone).
             end_date: Optional end date (mandatory for GraphQL; REST uses a
-                single-day request and ignores this value).
+                single-day request and requires an identical date if provided).
             interval: Interval type:
                 - "INTERVAL_QUARTER": Quarter-hour prices (15 min) - default
                 - "INTERVAL_HOUR": Hourly prices
@@ -87,6 +88,32 @@ class EnergyZero:
             local_tz=local_tz,
         )
 
+    async def get_electricity_prices_by_type(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: Interval | str = Interval.QUARTER,
+        *,
+        price_types: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]:
+        """Get multiple electricity price types with one backend request.
+
+        Uses the same date, timezone and interval semantics as
+        ``get_electricity_prices``. Values are in EUR/kWh.
+        ``price_types`` accepts an iterable; duplicates are returned once,
+        in first-requested order. An empty iterable raises ``ValueError``
+        before making a request. Returns a mapping of types to EnergyPrices.
+        """
+        interval_value = interval.value if isinstance(interval, Interval) else interval
+        return await self._client.get_electricity_prices_by_type(
+            start_date,
+            end_date,
+            interval_value,
+            price_types=price_types,
+            local_tz=local_tz,
+        )
+
     async def get_gas_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -103,7 +130,7 @@ class EnergyZero:
         ----
             start_date: Start date of the period (local timezone).
             end_date: Optional end date (mandatory for GraphQL; REST uses a
-                single-day request and ignores this value).
+                single-day request and requires an identical date if provided).
             price_type: Desired price flavor. See ``PriceType`` for the available
                 market/all-in options with or without VAT (default: ``ALL_IN``).
             local_tz: Timezone used to interpret the requested local date range.
@@ -117,6 +144,29 @@ class EnergyZero:
             start_date,
             end_date,
             price_type,
+            local_tz=local_tz,
+        )
+
+    async def get_gas_prices_by_type(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        *,
+        price_types: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]:
+        """Get multiple gas price types with one backend request.
+
+        Uses the same date, timezone and interval semantics as
+        ``get_gas_prices``. Values are in EUR/m³.
+        ``price_types`` accepts an iterable; duplicates are returned once,
+        in first-requested order. An empty iterable raises ``ValueError``
+        before making a request. Returns a mapping of types to EnergyPrices.
+        """
+        return await self._client.get_gas_prices_by_type(
+            start_date,
+            end_date,
+            price_types=price_types,
             local_tz=local_tz,
         )
 

--- a/src/energyzero/energyzero.py
+++ b/src/energyzero/energyzero.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Self, overload
 
 from energyzero.api import APIBackend, EnergyZeroAPIProtocol
 from energyzero.api.graphql import GraphQLClient
@@ -49,6 +49,7 @@ class EnergyZero:
         if self.session is None:
             self._close_session = True
 
+    @overload
     async def get_electricity_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -57,10 +58,46 @@ class EnergyZero:
         price_type: PriceType = PriceType.ALL_IN,
         *,
         local_tz: tzinfo | None = None,
-    ) -> EnergyPrices:
+    ) -> EnergyPrices: ...
+
+    @overload
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None,
+        interval: Interval | str,
+        price_type: Iterable[PriceType],
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    @overload
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: Interval | str = Interval.QUARTER,
+        *,
+        price_type: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    async def get_electricity_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        interval: Interval | str = Interval.QUARTER,
+        price_type: PriceType | Iterable[PriceType] = PriceType.ALL_IN,
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> EnergyPrices | dict[PriceType, EnergyPrices]:
         """Get electricity prices for a given period.
 
         All returned price values are in EUR/kWh.
+
+        Iterable input always returns a mapping, even for one type. Duplicates
+        appear once, in first-requested order. Empty iterables raise ValueError
+        before any request. All requested types use one backend request.
 
         Args:
         ----
@@ -70,13 +107,12 @@ class EnergyZero:
             interval: Interval type:
                 - "INTERVAL_QUARTER": Quarter-hour prices (15 min) - default
                 - "INTERVAL_HOUR": Hourly prices
-            price_type: Desired price flavor. See ``PriceType`` for the available
-                market/all-in options with or without VAT (default: ``ALL_IN``).
+            price_type: One PriceType or an iterable of types (default: ALL_IN).
             local_tz: Timezone used to interpret the requested local date range.
 
         Returns:
         -------
-            An EnergyPrices object with the requested prices.
+            One EnergyPrices for a single PriceType; a mapping for an iterable.
 
         """
         interval_value = interval.value if isinstance(interval, Interval) else interval
@@ -88,32 +124,7 @@ class EnergyZero:
             local_tz=local_tz,
         )
 
-    async def get_electricity_prices_by_type(  # pylint: disable=too-many-arguments
-        self,
-        start_date: date,
-        end_date: date | None = None,
-        interval: Interval | str = Interval.QUARTER,
-        *,
-        price_types: Iterable[PriceType],
-        local_tz: tzinfo | None = None,
-    ) -> dict[PriceType, EnergyPrices]:
-        """Get multiple electricity price types with one backend request.
-
-        Uses the same date, timezone and interval semantics as
-        ``get_electricity_prices``. Values are in EUR/kWh.
-        ``price_types`` accepts an iterable; duplicates are returned once,
-        in first-requested order. An empty iterable raises ``ValueError``
-        before making a request. Returns a mapping of types to EnergyPrices.
-        """
-        interval_value = interval.value if isinstance(interval, Interval) else interval
-        return await self._client.get_electricity_prices_by_type(
-            start_date,
-            end_date,
-            interval_value,
-            price_types=price_types,
-            local_tz=local_tz,
-        )
-
+    @overload
     async def get_gas_prices(  # pylint: disable=too-many-arguments
         self,
         start_date: date,
@@ -121,52 +132,61 @@ class EnergyZero:
         price_type: PriceType = PriceType.ALL_IN,
         *,
         local_tz: tzinfo | None = None,
-    ) -> EnergyPrices:
+    ) -> EnergyPrices: ...
+
+    @overload
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None,
+        price_type: Iterable[PriceType],
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    @overload
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        *,
+        price_type: Iterable[PriceType],
+        local_tz: tzinfo | None = None,
+    ) -> dict[PriceType, EnergyPrices]: ...
+
+    async def get_gas_prices(  # pylint: disable=too-many-arguments
+        self,
+        start_date: date,
+        end_date: date | None = None,
+        price_type: PriceType | Iterable[PriceType] = PriceType.ALL_IN,
+        *,
+        local_tz: tzinfo | None = None,
+    ) -> EnergyPrices | dict[PriceType, EnergyPrices]:
         """Get gas prices for a given period.
 
         All returned price values are in EUR/m³.
+
+        Iterable input always returns a mapping, even for one type. Duplicates
+        appear once, in first-requested order. Empty iterables raise ValueError
+        before any request. All requested types use one backend request.
 
         Args:
         ----
             start_date: Start date of the period (local timezone).
             end_date: Optional end date (mandatory for GraphQL; REST uses a
                 single-day request and requires an identical date if provided).
-            price_type: Desired price flavor. See ``PriceType`` for the available
-                market/all-in options with or without VAT (default: ``ALL_IN``).
+            price_type: One PriceType or an iterable of types (default: ALL_IN).
             local_tz: Timezone used to interpret the requested local date range.
 
         Returns:
         -------
-            An EnergyPrices object with the requested prices.
+            One EnergyPrices for a single PriceType; a mapping for an iterable.
 
         """
         return await self._client.get_gas_prices(
             start_date,
             end_date,
             price_type,
-            local_tz=local_tz,
-        )
-
-    async def get_gas_prices_by_type(  # pylint: disable=too-many-arguments
-        self,
-        start_date: date,
-        end_date: date | None = None,
-        *,
-        price_types: Iterable[PriceType],
-        local_tz: tzinfo | None = None,
-    ) -> dict[PriceType, EnergyPrices]:
-        """Get multiple gas price types with one backend request.
-
-        Uses the same date, timezone and interval semantics as
-        ``get_gas_prices``. Values are in EUR/m³.
-        ``price_types`` accepts an iterable; duplicates are returned once,
-        in first-requested order. An empty iterable raises ``ValueError``
-        before making a request. Returns a mapping of types to EnergyPrices.
-        """
-        return await self._client.get_gas_prices_by_type(
-            start_date,
-            end_date,
-            price_types=price_types,
             local_tz=local_tz,
         )
 

--- a/tests/test_multiple_price_types.py
+++ b/tests/test_multiple_price_types.py
@@ -1,0 +1,257 @@
+"""Test retrieving multiple price types with one backend request."""
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+from aresponses import ResponsesMockServer
+
+from energyzero import APIBackend, EnergyZero, Interval, PriceType
+from energyzero.exceptions import EnergyZeroNoDataError
+
+from . import load_fixtures
+
+
+@pytest.mark.parametrize(
+    ("kind", "interval", "fixture"),
+    [
+        ("electricity", Interval.HOUR, "electricity_hour_response"),
+        ("electricity", Interval.QUARTER, "electricity_quarter_response"),
+        ("gas", Interval.DAY, "gas_day_response"),
+    ],
+)
+async def test_rest_multiple_types(
+    aresponses: ResponsesMockServer,
+    energyzero_client: EnergyZero,
+    kind: str,
+    interval: Interval,
+    fixture: str,
+) -> None:
+    """Fetch all streams once, filtering every stream to the local day."""
+    payload = json.loads(load_fixtures(f"rest/{fixture}.json"))
+    aresponses.add(
+        "public.api.energyzero.nl",
+        f"/public/v1/prices?energyType=ENERGY_TYPE_{kind.upper()}"
+        f"&date=17-12-2025&interval={interval.value}",
+        "GET",
+        aresponses.Response(
+            text=json.dumps(payload), headers={"Content-Type": "application/json"}
+        ),
+        match_querystring=True,
+    )
+    local_tz = ZoneInfo("Europe/Amsterdam")
+    requested_date = date(2025, 12, 17)
+    method = getattr(energyzero_client, f"get_{kind}_prices_by_type")
+    result = await method(
+        requested_date,
+        price_types=iter([*PriceType, PriceType.ALL_IN]),
+        local_tz=local_tz,
+        **({"interval": interval} if kind == "electricity" else {}),
+    )
+    assert list(result) == list(PriceType)
+    count = {Interval.HOUR: 24, Interval.QUARTER: 96, Interval.DAY: 1}[interval]
+    for price_type, stream in (
+        (PriceType.MARKET, "base"),
+        (PriceType.MARKET_WITH_VAT, "base_with_vat"),
+        (PriceType.ALL_IN_EXCL_VAT, "all_in"),
+        (PriceType.ALL_IN, "all_in_with_vat"),
+    ):
+        expected = [
+            float(item["price"]["value"])
+            for item in payload[stream]
+            if datetime.fromisoformat(item["start"]).astimezone(local_tz).date()
+            == requested_date
+        ]
+        prices = result[price_type]
+        assert len(prices.prices) == count
+        assert list(prices.prices.values()) == expected
+        assert prices.average_price == pytest.approx(sum(expected) / count)
+        assert all(
+            time_range.start_including.astimezone(local_tz).date() == requested_date
+            for time_range in prices.prices
+        )
+    assert len(aresponses.history) == 1
+    aresponses.assert_plan_strictly_followed()
+
+
+@pytest.mark.parametrize("backend", list(APIBackend))
+@pytest.mark.parametrize("kind", ["electricity", "gas"])
+async def test_empty_types(backend: APIBackend, kind: str) -> None:
+    """Reject an empty iterable without contacting the backend."""
+    async with EnergyZero(backend=backend) as client:
+        with (
+            patch.object(client._client, "_request") as request,
+            pytest.raises(ValueError, match="At least one price type"),
+        ):
+            await getattr(client, f"get_{kind}_prices_by_type")(
+                date(2025, 12, 17), price_types=iter(())
+            )
+        request.assert_not_called()
+
+
+@pytest.mark.parametrize("kind", ["electricity", "gas"])
+@pytest.mark.parametrize("backend", list(APIBackend))
+async def test_invalid_dates(backend: APIBackend, kind: str) -> None:
+    """Keep backend date validation and reject invalid dates before requesting."""
+    async with EnergyZero(backend=backend) as client:
+        with (
+            patch.object(client._client, "_request") as request,
+            pytest.raises(ValueError, match=r"single-day|end_date is required"),
+        ):
+            await getattr(client, f"get_{kind}_prices_by_type")(
+                date(2025, 12, 17),
+                date(2025, 12, 18) if backend == APIBackend.REST else None,
+                price_types=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
+            )
+        request.assert_not_called()
+
+
+@pytest.mark.parametrize("kind", ["electricity", "gas"])
+@pytest.mark.parametrize("stream_state", ["empty", "other_day", "absent"])
+async def test_missing_requested_day(
+    energyzero_client: EnergyZero, kind: str, stream_state: str
+) -> None:
+    """Fail the whole call if one requested stream has no prices for the day."""
+    fixture = (
+        "electricity_hour_response" if kind == "electricity" else "gas_day_response"
+    )
+    payload = json.loads(load_fixtures(f"rest/{fixture}.json"))
+    payload["all_in_with_vat"] = (
+        [] if stream_state == "empty" else [payload["all_in_with_vat"][0]]
+    )
+    if stream_state == "absent":
+        del payload["all_in_with_vat"]
+    with (
+        patch.object(
+            energyzero_client._client, "_request", return_value=payload
+        ) as request,
+        pytest.raises(EnergyZeroNoDataError, match="2025-12-17"),
+    ):
+        await getattr(energyzero_client, f"get_{kind}_prices_by_type")(
+            date(2025, 12, 17),
+            price_types=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
+            local_tz=ZoneInfo("Europe/Amsterdam"),
+        )
+    request.assert_awaited_once()
+
+
+@pytest.mark.parametrize("kind", ["electricity", "gas"])
+async def test_graphql_multiple_types(
+    aresponses: ResponsesMockServer,
+    graphql_energyzero_client: EnergyZero,
+    kind: str,
+) -> None:
+    """Build all GraphQL price flavors from one response."""
+    fixture = "energy" if kind == "electricity" else "gas"
+    payload = json.loads(load_fixtures(f"graphql/{fixture}.json"))
+    aresponses.add(
+        "api.energyzero.nl",
+        "/v1/gql",
+        "POST",
+        aresponses.Response(
+            text=json.dumps(payload), headers={"Content-Type": "application/json"}
+        ),
+    )
+    result = await getattr(graphql_energyzero_client, f"get_{kind}_prices_by_type")(
+        date(2025, 5, 31), date(2025, 6, 1), price_types=iter(PriceType)
+    )
+    assert list(result) == list(PriceType)
+    items = payload["data"]["energyMarketPrices"]["prices"]
+    for price_type, field, cost_field in (
+        (PriceType.MARKET, "energyPriceExcl", None),
+        (PriceType.MARKET_WITH_VAT, "energyPriceIncl", None),
+        (PriceType.ALL_IN_EXCL_VAT, "energyPriceExcl", "priceExcl"),
+        (PriceType.ALL_IN, "energyPriceIncl", "priceIncl"),
+    ):
+        expected = [
+            item[field]
+            + (
+                sum(cost[cost_field] for cost in item["additionalCosts"])
+                if cost_field
+                else 0
+            )
+            for item in items
+        ]
+        assert list(result[price_type].prices.values()) == expected
+        assert result[price_type].average_price == pytest.approx(
+            sum(expected) / len(expected)
+        )
+    assert len(aresponses.history) == 1
+    aresponses.assert_plan_strictly_followed()
+
+
+@pytest.mark.parametrize(
+    ("day", "hours"), [(date(2025, 3, 30), 23), (date(2025, 10, 26), 25)]
+)
+async def test_multiple_types_dst(
+    energyzero_client: EnergyZero, day: date, hours: int
+) -> None:
+    """Keep the full local day across both daylight saving transitions."""
+    local_tz = ZoneInfo("Europe/Amsterdam")
+    midnight = datetime.combine(day, datetime.min.time(), local_tz).astimezone(UTC)
+    payload = {
+        stream: [
+            {
+                "start": (midnight + timedelta(hours=hour)).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+                "end": (midnight + timedelta(hours=hour + 1)).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+                "price": {"value": str(value)},
+            }
+            for hour in range(-2, hours + 2)
+        ]
+        for value, stream in enumerate(
+            ("base", "base_with_vat", "all_in", "all_in_with_vat")
+        )
+    }
+    with patch.object(
+        energyzero_client._client, "_request", return_value=payload
+    ) as request:
+        result = await energyzero_client.get_electricity_prices_by_type(
+            day, interval=Interval.HOUR, price_types=PriceType, local_tz=local_tz
+        )
+    request.assert_awaited_once()
+    for prices in result.values():
+        assert len(prices.prices) == hours
+        assert all(
+            timerange.start_including.astimezone(local_tz).date() == day
+            for timerange in prices.prices
+        )
+
+
+@pytest.mark.parametrize("backend", list(APIBackend))
+@pytest.mark.parametrize("kind", ["electricity", "gas"])
+async def test_subset_and_single_price_compatibility(
+    backend: APIBackend, kind: str
+) -> None:
+    """Preserve single-price defaults and return only the requested types."""
+    if backend == APIBackend.REST:
+        fixture = (
+            "electricity_hour_response" if kind == "electricity" else "gas_day_response"
+        )
+    else:
+        fixture = "energy" if kind == "electricity" else "gas"
+    payload = json.loads(load_fixtures(f"{backend.value}/{fixture}.json"))
+    async with EnergyZero(backend=backend) as client:
+        with patch.object(client._client, "_request", return_value=payload) as request:
+            method = getattr(client, f"get_{kind}_prices_by_type")
+            result = await method(
+                date(2025, 12, 17),
+                date(2025, 12, 17),
+                price_types=iter(
+                    (PriceType.ALL_IN, PriceType.MARKET_WITH_VAT, PriceType.ALL_IN)
+                ),
+                local_tz=ZoneInfo("Europe/Amsterdam"),
+            )
+            request.assert_awaited_once()
+            assert list(result) == [PriceType.ALL_IN, PriceType.MARKET_WITH_VAT]
+            single = await getattr(client, f"get_{kind}_prices")(
+                date(2025, 12, 17),
+                date(2025, 12, 17),
+                local_tz=ZoneInfo("Europe/Amsterdam"),
+            )
+            assert single == result[PriceType.ALL_IN]

--- a/tests/test_multiple_price_types.py
+++ b/tests/test_multiple_price_types.py
@@ -2,13 +2,14 @@
 
 import json
 from datetime import UTC, date, datetime, timedelta
+from typing import assert_type
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import pytest
 from aresponses import ResponsesMockServer
 
-from energyzero import APIBackend, EnergyZero, Interval, PriceType
+from energyzero import APIBackend, EnergyPrices, EnergyZero, Interval, PriceType
 from energyzero.exceptions import EnergyZeroNoDataError
 
 from . import load_fixtures
@@ -43,10 +44,10 @@ async def test_rest_multiple_types(
     )
     local_tz = ZoneInfo("Europe/Amsterdam")
     requested_date = date(2025, 12, 17)
-    method = getattr(energyzero_client, f"get_{kind}_prices_by_type")
+    method = getattr(energyzero_client, f"get_{kind}_prices")
     result = await method(
         requested_date,
-        price_types=iter([*PriceType, PriceType.ALL_IN]),
+        price_type=iter([*PriceType, PriceType.ALL_IN]),
         local_tz=local_tz,
         **({"interval": interval} if kind == "electricity" else {}),
     )
@@ -85,8 +86,8 @@ async def test_empty_types(backend: APIBackend, kind: str) -> None:
             patch.object(client._client, "_request") as request,
             pytest.raises(ValueError, match="At least one price type"),
         ):
-            await getattr(client, f"get_{kind}_prices_by_type")(
-                date(2025, 12, 17), price_types=iter(())
+            await getattr(client, f"get_{kind}_prices")(
+                date(2025, 12, 17), price_type=iter(())
             )
         request.assert_not_called()
 
@@ -100,10 +101,10 @@ async def test_invalid_dates(backend: APIBackend, kind: str) -> None:
             patch.object(client._client, "_request") as request,
             pytest.raises(ValueError, match=r"single-day|end_date is required"),
         ):
-            await getattr(client, f"get_{kind}_prices_by_type")(
+            await getattr(client, f"get_{kind}_prices")(
                 date(2025, 12, 17),
                 date(2025, 12, 18) if backend == APIBackend.REST else None,
-                price_types=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
+                price_type=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
             )
         request.assert_not_called()
 
@@ -129,9 +130,9 @@ async def test_missing_requested_day(
         ) as request,
         pytest.raises(EnergyZeroNoDataError, match="2025-12-17"),
     ):
-        await getattr(energyzero_client, f"get_{kind}_prices_by_type")(
+        await getattr(energyzero_client, f"get_{kind}_prices")(
             date(2025, 12, 17),
-            price_types=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
+            price_type=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
             local_tz=ZoneInfo("Europe/Amsterdam"),
         )
     request.assert_awaited_once()
@@ -154,8 +155,8 @@ async def test_graphql_multiple_types(
             text=json.dumps(payload), headers={"Content-Type": "application/json"}
         ),
     )
-    result = await getattr(graphql_energyzero_client, f"get_{kind}_prices_by_type")(
-        date(2025, 5, 31), date(2025, 6, 1), price_types=iter(PriceType)
+    result = await getattr(graphql_energyzero_client, f"get_{kind}_prices")(
+        date(2025, 5, 31), date(2025, 6, 1), price_type=iter(PriceType)
     )
     assert list(result) == list(PriceType)
     items = payload["data"]["energyMarketPrices"]["prices"]
@@ -211,8 +212,8 @@ async def test_multiple_types_dst(
     with patch.object(
         energyzero_client._client, "_request", return_value=payload
     ) as request:
-        result = await energyzero_client.get_electricity_prices_by_type(
-            day, interval=Interval.HOUR, price_types=PriceType, local_tz=local_tz
+        result = await energyzero_client.get_electricity_prices(
+            day, interval=Interval.HOUR, price_type=PriceType, local_tz=local_tz
         )
     request.assert_awaited_once()
     for prices in result.values():
@@ -238,11 +239,11 @@ async def test_subset_and_single_price_compatibility(
     payload = json.loads(load_fixtures(f"{backend.value}/{fixture}.json"))
     async with EnergyZero(backend=backend) as client:
         with patch.object(client._client, "_request", return_value=payload) as request:
-            method = getattr(client, f"get_{kind}_prices_by_type")
+            method = getattr(client, f"get_{kind}_prices")
             result = await method(
                 date(2025, 12, 17),
                 date(2025, 12, 17),
-                price_types=iter(
+                price_type=iter(
                     (PriceType.ALL_IN, PriceType.MARKET_WITH_VAT, PriceType.ALL_IN)
                 ),
                 local_tz=ZoneInfo("Europe/Amsterdam"),
@@ -255,3 +256,85 @@ async def test_subset_and_single_price_compatibility(
                 local_tz=ZoneInfo("Europe/Amsterdam"),
             )
             assert single == result[PriceType.ALL_IN]
+
+
+@pytest.mark.parametrize("backend", list(APIBackend))
+@pytest.mark.parametrize("kind", ["electricity", "gas"])
+@pytest.mark.parametrize("container", [tuple, list, set, iter])
+async def test_singleton_iterable(
+    backend: APIBackend, kind: str, container: type
+) -> None:
+    """An iterable with one type returns a mapping, including positional calls."""
+    if backend == APIBackend.REST:
+        fixture = (
+            "electricity_hour_response" if kind == "electricity" else "gas_day_response"
+        )
+    else:
+        fixture = "energy" if kind == "electricity" else "gas"
+    payload = json.loads(load_fixtures(f"{backend.value}/{fixture}.json"))
+    day = date(2025, 12, 17)
+    async with EnergyZero(backend=backend) as client:
+        with patch.object(client._client, "_request", return_value=payload) as request:
+            selected = container([PriceType.MARKET_WITH_VAT])
+            if kind == "electricity":
+                result = await client.get_electricity_prices(
+                    day, day, Interval.HOUR, selected
+                )
+            else:
+                result = await client.get_gas_prices(day, day, selected)
+            request.assert_awaited_once()
+            assert isinstance(result, dict)
+            assert list(result) == [PriceType.MARKET_WITH_VAT]
+            assert isinstance(result[PriceType.MARKET_WITH_VAT], EnergyPrices)
+
+
+@pytest.mark.parametrize("backend", list(APIBackend))
+async def test_return_type_overloads(backend: APIBackend) -> None:
+    """Check type inference alongside actual return values for both methods."""
+    payload = json.loads(
+        load_fixtures(
+            "rest/electricity_hour_response.json"
+            if backend == APIBackend.REST
+            else "graphql/energy.json"
+        )
+    )
+    day = date(2025, 12, 17)
+    async with EnergyZero(backend=backend) as client:
+        with patch.object(client._client, "_request", return_value=payload):
+            electricity = assert_type(
+                await client.get_electricity_prices(day, day), EnergyPrices
+            )
+            gas = assert_type(await client.get_gas_prices(day, day), EnergyPrices)
+            assert isinstance(electricity, EnergyPrices)
+            assert isinstance(gas, EnergyPrices)
+            assert_type(
+                await client.get_electricity_prices(
+                    day, day, Interval.HOUR, PriceType.ALL_IN
+                ),
+                EnergyPrices,
+            )
+            assert_type(
+                await client.get_gas_prices(day, day, PriceType.ALL_IN), EnergyPrices
+            )
+            electricity_types = assert_type(
+                await client.get_electricity_prices(
+                    day, day, price_type=(PriceType.ALL_IN,)
+                ),
+                dict[PriceType, EnergyPrices],
+            )
+            gas_types = assert_type(
+                await client.get_gas_prices(day, day, price_type=(PriceType.ALL_IN,)),
+                dict[PriceType, EnergyPrices],
+            )
+            assert electricity_types == {PriceType.ALL_IN: electricity}
+            assert gas_types == {PriceType.ALL_IN: gas}
+            assert_type(
+                await client.get_electricity_prices(
+                    day, day, Interval.HOUR, iter(PriceType)
+                ),
+                dict[PriceType, EnergyPrices],
+            )
+            assert_type(
+                await client.get_gas_prices(day, day, [PriceType.ALL_IN]),
+                dict[PriceType, EnergyPrices],
+            )

--- a/tests/test_multiple_price_types.py
+++ b/tests/test_multiple_price_types.py
@@ -2,7 +2,7 @@
 
 import json
 from datetime import UTC, date, datetime, timedelta
-from typing import assert_type
+from typing import assert_type, cast
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
@@ -338,3 +338,58 @@ async def test_return_type_overloads(backend: APIBackend) -> None:
                 await client.get_gas_prices(day, day, [PriceType.ALL_IN]),
                 dict[PriceType, EnergyPrices],
             )
+
+
+@pytest.mark.parametrize("backend", list(APIBackend))
+@pytest.mark.parametrize("kind", ["electricity", "gas"])
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        pytest.param("all_in", id="bare-string"),
+        pytest.param("", id="empty-string"),
+        pytest.param(b"all_in", id="bytes"),
+        pytest.param(42, id="non-iterable"),
+        pytest.param(["all_in"], id="string-item"),
+        pytest.param([42], id="integer-item"),
+        pytest.param([[]], id="unhashable-item"),
+        pytest.param([PriceType.ALL_IN, "all_in"], id="equal-string-after-enum"),
+        pytest.param(["all_in", PriceType.ALL_IN], id="equal-string-before-enum"),
+    ],
+)
+async def test_invalid_price_types(
+    backend: APIBackend, kind: str, invalid: object
+) -> None:
+    """Reject invalid input before requesting or deduplicating enum-like strings."""
+    async with EnergyZero(backend=backend) as client:
+        method = (
+            client.get_electricity_prices
+            if kind == "electricity"
+            else client.get_gas_prices
+        )
+        with (
+            patch.object(client._client, "_request") as request,
+            pytest.raises(TypeError, match="PriceType"),
+        ):
+            await method(
+                date(2025, 12, 17),
+                date(2025, 12, 17),
+                price_type=cast("PriceType", invalid),
+            )
+        request.assert_not_called()
+
+
+@pytest.mark.parametrize("backend", list(APIBackend))
+@pytest.mark.parametrize("kind", ["electricity", "gas"])
+async def test_invalid_generator(backend: APIBackend, kind: str) -> None:
+    """Validate all generator items before making a backend request."""
+    async with EnergyZero(backend=backend) as client:
+        with (
+            patch.object(client._client, "_request") as request,
+            pytest.raises(TypeError, match="Every item"),
+        ):
+            await getattr(client, f"get_{kind}_prices")(
+                date(2025, 12, 17),
+                date(2025, 12, 17),
+                price_type=iter([PriceType.ALL_IN, "market"]),
+            )
+        request.assert_not_called()


### PR DESCRIPTION
Consumers requesting both market-with-VAT and all-in prices currently make two identical HTTP requests. Extend the existing `price_type` parameter on `get_electricity_prices()` and `get_gas_prices()` to accept an iterable, retrieving all requested price types with one HTTP request per call on both REST and GraphQL.

```python
prices = await client.get_electricity_prices(
    start_date=today,
    price_type=(PriceType.MARKET_WITH_VAT, PriceType.ALL_IN),
    local_tz=local_tz,
)
market_prices = prices[PriceType.MARKET_WITH_VAT]
all_in_prices = prices[PriceType.ALL_IN]
```

A single `PriceType` still returns `EnergyPrices`, and the default remains `PriceType.ALL_IN`. Iterable input always returns `dict[PriceType, EnergyPrices]`, including one-element iterables. Overloads infer the return type for both keyword and positional arguments. Duplicate types appear once in first-requested order, and empty iterables fail before any request. Invalid inputs, including raw strings and mixed iterables, raise a clear `TypeError` before deduplication or any backend request.

REST filters every requested stream to the local date, including daylight saving transitions. Missing or empty requested streams raise `EnergyZeroNoDataError` without returning a partial mapping. GraphQL retains its existing date-range behavior. README examples document the API.

Closes #1216
